### PR TITLE
Support secret param

### DIFF
--- a/fluent-plugin-sndacs.gemspec
+++ b/fluent-plugin-sndacs.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.email = 'popeast@gmail.com'
   gem.files = `git ls-files`.split("\n")
 
-  gem.add_dependency 'fluentd', '~>0.10.28'
+  gem.add_dependency 'fluentd', ['>= 0.10.28', '< 2']
   gem.add_dependency 'sndacs', '~>0.2.4'
 end
 

--- a/lib/fluent/plugin/out_sndacs.rb
+++ b/lib/fluent/plugin/out_sndacs.rb
@@ -16,8 +16,8 @@ module Fluent
     end
 
     config_param :path, :string, :default => ''
-    config_param :access_key_id, :string
-    config_param :secret_access_key, :string
+    config_param :access_key_id, :string, :secret => true
+    config_param :secret_access_key, :string, :secret => true
     config_param :bucket, :string
 
     def configure(conf)


### PR DESCRIPTION
`access_key_id` and `secret_access_key` contain sensitive information.
These parameters should be concealed with secret parameter feature.

AFAIK, Fluentd 0.12 has backward compatibility.
So, it can be loosen Fluentd gem dependency.